### PR TITLE
updated column spacing to 0.5in to match ans word template

### DIFF
--- a/anstrans.cls
+++ b/anstrans.cls
@@ -25,6 +25,7 @@
 
 %%%%%%%%%%% TYPE AND GEOMETRY %%%%%%%%%%%
 \LoadClass[twocolumn,10pt]{article}
+\setlength{\columnsep}{0.5in}
 
 \pagestyle{empty}						%no page numbering
 


### PR DESCRIPTION
I just got an email from ANS headquarters telling me my columns were too close together. Here's the update to 0.5in spacing.
