### PR TITLE
Making the disclaimer span entire textwidth.

### DIFF
--- a/anstrans.cls
+++ b/anstrans.cls
@@ -21,6 +21,7 @@
 \pagestyle{empty}						%no page numbering
 
 \RequirePackage[text={7in,9in},centering,columnsep=18pt]{geometry}
+\RequirePackage{fancyhdr}
 
 % ams math must be loaded before txfonts
 \usepackage{amsmath}
@@ -29,6 +30,15 @@
 \RequirePackage{txfonts}
 % bold math must be loaded after Times font
 \usepackage{bm}
+
+%%%%%%%%%%% TITLE PAGE FORMAT %%%%%%%%%%%
+\fancypagestyle{firstpage}{
+    \renewcommand{\headrulewidth}{0pt}
+    \renewcommand{\footrulewidth}{0.5pt}
+    \rhead{}
+    \cfoot{}
+    \lfoot{\footnotesize \@disclaimer}
+}
 
 %%%%%%%%%%% INCLUDE PACKAGES %%%%%%%%%%%
 \RequirePackage{cuted} % defines 'strip' environment for single column
@@ -167,7 +177,7 @@
 
   %disclaimer
   \if@disclaimerdefined%
-  {\footnotetext[1]{\footnotesize \@disclaimer}}%
+    \thispagestyle{firstpage}
   \fi
 }
 

--- a/example.tex
+++ b/example.tex
@@ -14,7 +14,8 @@ $^{\dagger}$State Capitol Building, Springfield, IL
 
 % Optional disclaimer: remove this command to hide
 \disclaimer{Notice: this manuscript is a work of fiction. Any resemblance to
-actual articles, living or dead, is purely coincidental.}
+actual articles, living or dead, is purely coincidental. Some facilities require long
+disclaimers ... Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus placerat purus sit amet varius porta. Phasellus mollis gravida ultrices. Sed eu mollis orci. Proin id fermentum nibh. Cras fermentum mi et ipsum fringilla, vitae facilisis dui facilisis. Suspendisse id blandit neque. Morbi eget augue vel dui elementum laoreet et lobortis eros. Pellentesque quis luctus diam. Curabitur neque diam, feugiat eu malesuada vitae, sodales vitae metus. Maecenas ultricies ... }
 
 %%%% packages and definitions (optional)
 \usepackage{graphicx} % allows inclusion of graphics


### PR DESCRIPTION
Previous version only had disclaimer under the first column, and long disclaimers would not fit on the page well. This change modifies the footer on the first page if the disclaimer is present.