### PR TITLE
Removing footnote mark on title.

### DIFF
--- a/anstrans.cls
+++ b/anstrans.cls
@@ -155,7 +155,7 @@
   \begin{strip}%
     \centering%
       %title
-      {\bf \@title\if@disclaimerdefined{\footnotemark[1]{}}\fi}
+      {\bf \@title}
       \vspace{.75\baselineskip}%
 
       %author


### PR DESCRIPTION
The footnote symbol next to the title was not necessary.

I just noticed that I had forgotten to remove the footnote mark on the title in my last modification.